### PR TITLE
Update index.en-US.mdx

### DIFF
--- a/pages/index.en-US.mdx
+++ b/pages/index.en-US.mdx
@@ -13,6 +13,8 @@ import { Code } from '../components/Code'
 
 ### Prerequisites
 
+- If you haven't already, [enable developer mode](https://awful.wtf/account).
+
 - If you haven't already, [download awful](https://awful.wtf/download).
 
 - _If you don't already have a code editor, grab [VSCode](https://code.visualstudio.com/)._


### PR DESCRIPTION
added a step and a https://path to enable developer mode for those who got the awful doc from a link and did not enable developer mode.